### PR TITLE
Fixes regression that causes incompatibility with pouchdb-wrappers.

### DIFF
--- a/packages/node_modules/pouchdb-replication/src/index.js
+++ b/packages/node_modules/pouchdb-replication/src/index.js
@@ -8,14 +8,17 @@ function replication(PouchDB) {
   Object.defineProperty(PouchDB.prototype, 'replicate', {
     get: function () {
       var self = this;
-      return {
-        from: function (other, opts, callback) {
-          return self.constructor.replicate(other, self, opts, callback);
-        },
-        to: function (other, opts, callback) {
-          return self.constructor.replicate(self, other, opts, callback);
-        }
-      };
+      if (typeof this.replicateMethods === 'undefined') {
+        this.replicateMethods = {
+          from: function (other, opts, callback) {
+            return self.constructor.replicate(other, self, opts, callback);
+          },
+          to: function (other, opts, callback) {
+            return self.constructor.replicate(self, other, opts, callback);
+          }
+        };
+      }
+      return this.replicateMethods;
     }
   });
 


### PR DESCRIPTION
`installWrappers()` from pouchdb-wrappers patches original methods with
the `_handlers` attribute, but because `Pouchdb.replicate()` is a
property which returns a new object every time, the patched `from` and
`to` methods were actually lost.

Refs ceaeeb72ae6c2ff653cac1ad09f5f242ab21accf.